### PR TITLE
[WIP] fix firewall rules replaced.

### DIFF
--- a/tests/integration/targets/vyos_firewall_rules/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_firewall_rules/tests/cli/replaced.yaml
@@ -28,6 +28,16 @@
                     description: Rule 101 is configured by Ansible
                     protocol: tcp
 
+                  - number: 103
+                    action: accept
+                    description: Rule 103 is configured by Ansible
+                    state:
+                      related: true
+                      established: true
+                    source:
+                      group:
+                        address_group: inbound #only modifying this field from a IP to a group
+
                   - number: 104
                     action: reject
                     description: Rule 104 is configured by Ansible

--- a/tests/integration/targets/vyos_firewall_rules/tests/cli/replaced.yaml
+++ b/tests/integration/targets/vyos_firewall_rules/tests/cli/replaced.yaml
@@ -36,7 +36,7 @@
                       established: true
                     source:
                       group:
-                        address_group: inbound #only modifying this field from a IP to a group
+                        address_group: inbound # only modifying this field from a IP to a group
 
                   - number: 104
                     action: reject

--- a/tests/integration/targets/vyos_firewall_rules/vars/pre-v1_4.yaml
+++ b/tests/integration/targets/vyos_firewall_rules/vars/pre-v1_4.yaml
@@ -69,7 +69,8 @@ replaced_commands:
   - delete firewall ipv6-name UPLINK rule 1
   - delete firewall ipv6-name UPLINK rule 2
   - delete firewall name INBOUND rule 102
-  - delete firewall name INBOUND rule 103
+  - delete firewall name INBOUND rule 103 source address
+  - set firewall name INBOUND rule 103 source group address-group 'inbound'
   - set firewall name INBOUND rule 104 action 'reject'
   - set firewall name INBOUND rule 104 description 'Rule 104 is configured by Ansible'
   - set firewall name INBOUND rule 104

--- a/tests/integration/targets/vyos_firewall_rules/vars/v1_4.yaml
+++ b/tests/integration/targets/vyos_firewall_rules/vars/v1_4.yaml
@@ -69,7 +69,6 @@ replaced_commands:
   - set firewall ipv4 name INBOUND rule 104 action 'reject'
   - set firewall ipv4 name INBOUND rule 104 description 'Rule 104 is configured by Ansible'
   - set firewall ipv4 name INBOUND rule 104
-  - set firewall ipv4 name INBOUND rule 104 protocol 'udp'
 
 overridden_commands:
   - delete firewall ipv6 name UPLINK

--- a/tests/integration/targets/vyos_firewall_rules/vars/v1_4.yaml
+++ b/tests/integration/targets/vyos_firewall_rules/vars/v1_4.yaml
@@ -65,10 +65,12 @@ replaced_commands:
   - delete firewall ipv6 name UPLINK rule 1
   - delete firewall ipv6 name UPLINK rule 2
   - delete firewall ipv4 name INBOUND rule 102
-  - delete firewall ipv4 name INBOUND rule 103
+  - delete firewall ipv4 name INBOUND rule 103 source address
+  - set firewall ipv4 name INBOUND rule 103 source group address-group 'inbound'
   - set firewall ipv4 name INBOUND rule 104 action 'reject'
   - set firewall ipv4 name INBOUND rule 104 description 'Rule 104 is configured by Ansible'
   - set firewall ipv4 name INBOUND rule 104
+  - set firewall ipv4 name INBOUND rule 104 protocol 'udp'
 
 overridden_commands:
   - delete firewall ipv6 name UPLINK


### PR DESCRIPTION
Integration tests can be executed with `andebox test -- network-integration --inventory hosts.ini vyos_firewall_rules`.

This is my `hosts.ini`, which need to be placed in the root of the repo and in `tests/integration`: 

```
[all:vars]
ansible_connection=ansible.netcommon.network_cli

[vyos]
test ansible_host=10.1.1.13

[vyos:vars]
ansible_network_os=vyos.vyos.vyos
ansible_user=vyos
ansible_password=vyos
```

The VM with VyOS needs to have this config:

3 network interfaces:
1. connected to a DHCP server
2. disconnected
3. disconnected

Run those commands after installation:

```
configure
set interface ethernet eth0 address dhcp
set service ssh port 22
commit
save
```